### PR TITLE
Postgres

### DIFF
--- a/RealEstate/settings/prod.py
+++ b/RealEstate/settings/prod.py
@@ -3,13 +3,18 @@ Settings that are specific to a production environment.
 """
 from RealEstate.settings.base import *
 
+ALLOWED_HOSTS = ['*']
 
 DEBUG = False
 TEMPLATE_DEBUG = False
 
-# Need to fill this in with our Postgres production settings.
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-#     }
-# }
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'RealEstate',                      
+        'USER': 'django',
+        'PASSWORD': '1234',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
+}

--- a/RealEstate/settings/prod.py
+++ b/RealEstate/settings/prod.py
@@ -3,7 +3,9 @@ Settings that are specific to a production environment.
 """
 from RealEstate.settings.base import *
 
-ALLOWED_HOSTS = ['*']
+STATIC_ROOT = "/opt/myenv/static/"
+
+ALLOWED_HOSTS = ['capstonedd.cs.pdx.edu']
 
 DEBUG = False
 TEMPLATE_DEBUG = False
@@ -11,10 +13,10 @@ TEMPLATE_DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'RealEstate',                      
-        'USER': 'django',
-        'PASSWORD': '1234',
+        'NAME': 'django',                      
+        'USER': 'postgres',
+        'PASSWORD': 'pass',
         'HOST': 'localhost',
-        'PORT': '5432',
+	'PORT': '',
     }
 }

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.dev")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.prod")
 
     from django.core.management import execute_from_command_line
 

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.prod")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.dev")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
In order to work on prod we changed manage.py change os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.dev") 
change below
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "RealEstate.settings.prod")
this only works on our capstone postgres server in order to pass the travis Sour have to install in travis.
