### PR TITLE
Report initial

### DIFF
--- a/RealEstate/apps/core/models.py
+++ b/RealEstate/apps/core/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import (AbstractBaseUser, BaseUserManager,
                                         PermissionsMixin)
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
+from django.core.urlresolvers import reverse
 from django.core.validators import (MaxValueValidator, MinValueValidator,
                                     RegexValidator)
 from django.db import IntegrityError, models
@@ -78,6 +79,15 @@ class Person(BaseModel):
     def __unicode__(self):
         name = self.full_name
         return name if name else self.email
+
+    def can_view_report_for_couple(self, couple_id):
+        """
+        Returns a boolean indicating whether or not the Person instance can
+        view the report for a given Couple.  This behavior will differ for the
+        different subclasses (Homebuyer/Realtor), so the implementations
+        should be defined there.
+        """
+        raise NotImplementedError
 
     @property
     def email(self):
@@ -193,6 +203,11 @@ class Couple(BaseModel):
             homebuyers = (homebuyers.first(), None)
         return homebuyers
 
+    def report_url(self):
+        if not self.id:
+            return None
+        return reverse('report', kwargs={'couple_id': self.id})
+
     class Meta:
         ordering = ['realtor']
         verbose_name = "Couple"
@@ -258,6 +273,12 @@ class Homebuyer(Person, ValidateCategoryCoupleMixin):
                                         through='core.CategoryWeight',
                                         verbose_name="Categories")
 
+    def can_view_report_for_couple(self, couple_id):
+        """
+        Homebuyers can only see their own report.
+        """
+        return self.couple_id == couple_id
+
     def clean(self):
         """
         Homebuyers and Realtors are mutually exclusive.  User instances have
@@ -296,6 +317,9 @@ class Homebuyer(Person, ValidateCategoryCoupleMixin):
                                  "should be resolved immediately. "
                                  "(Couple ID: {id})".format(id=self.couple_id))
         return related_homebuyers.first()
+
+    def report_url(self):
+        return self.couple.report_url()
 
     @property
     def role_type(self):
@@ -353,6 +377,12 @@ class Realtor(Person):
     Represents a realtor.  Each Couple instance has a required foreign key to
     Realtor, so each Realtor serves zero or more couples.
     """
+    def can_view_report_for_couple(self, couple_id):
+        """
+        Realtors can view all reports for their client Couples.
+        """
+        return self.couple_set.filter(id=couple_id).exists()
+
     def clean(self):
         """
         Homebuyers and Realtors are mutually exclusive.  User instances have

--- a/RealEstate/apps/core/templates/core/report.html
+++ b/RealEstate/apps/core/templates/core/report.html
@@ -1,0 +1,5 @@
+{% extends "core/base.html" %}
+
+{% block body %}
+   <h2><strong>REPORT</strong></h2>
+{% endblock body %}

--- a/RealEstate/apps/core/views.py
+++ b/RealEstate/apps/core/views.py
@@ -8,7 +8,8 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from django.http import HttpResponse
 
-from RealEstate.apps.core.models import Category, Couple, Grade, House, Homebuyer, User
+from RealEstate.apps.core.models import (Category, Couple, Grade, House,
+                                         Homebuyer, User)
 
 
 def login(request, *args, **kwargs):
@@ -116,7 +117,7 @@ class EvalView(BaseView):
 
         context = {
             'couple': couple,
-            'house' : house,
+            'house': house,
             'grades': graded,
         }
         context.update(self._score_context())
@@ -146,3 +147,24 @@ class EvalView(BaseView):
         }
         return HttpResponse(json.dumps(response_data),
                             content_type="application/json")
+
+
+class ReportView(BaseView):
+    """
+    This view will display take into account the category weights and scores
+    for each Homebuyer that is part of the Couple instance, and display the
+    results to the user.
+    """
+    template_name = 'core/report.html'
+
+    def _permission_check(self, request, role, *args, **kwargs):
+        """
+        Homebuyers can only see their own report.  Realtors can see reports
+        for any of their Couples
+        """
+        couple_id = int(kwargs.get('couple_id', 0))
+        get_object_or_404(Couple, id=couple_id)
+        return role.can_view_report_for_couple(couple_id)
+
+    def get(self, request, *args, **kwargs):
+        return render(request, self.template_name, {})

--- a/RealEstate/apps/core/views.py
+++ b/RealEstate/apps/core/views.py
@@ -151,9 +151,8 @@ class EvalView(BaseView):
 
 class ReportView(BaseView):
     """
-    This view will display take into account the category weights and scores
-    for each Homebuyer that is part of the Couple instance, and display the
-    results to the user.
+    This view will take into account the category weights and scores for each
+    Homebuyer that is part of the Couple instance, and display the results.
     """
     template_name = 'core/report.html'
 

--- a/RealEstate/urls.py
+++ b/RealEstate/urls.py
@@ -34,6 +34,9 @@ urlpatterns = [
         PendingViews.InviteHomebuyerView.as_view(), name='invite'),
     url(r'^signup/(?P<registration_token>[0-9a-f]{64})/$',
         PendingViews.SignupView.as_view(), name='signup'),
+    url(r'^eval/(?P<house_id>[\d]+)/$',
+        CoreViews.EvalView.as_view(), name='eval'),
+    url(r'^report/(?P<couple_id>[\d]+)/$',
+        CoreViews.ReportView.as_view(), name='report'),
     url(r'^$', CoreViews.HomeView.as_view(), name='home'),
-    url(r'^eval/(?P<house_id>[\d]+)/$', CoreViews.EvalView.as_view(), name='eval'),
 ]


### PR DESCRIPTION
Initial set up for the report view.  Right now the template just says REPORT when you go there.  Couple and Homebuyer instances can both call the report_url method to get a link to the report, which should be useful in templates.
