### PR TITLE
Add real smtp email backend for production settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 
 # Idea settings
 .idea/
+
+# Config file(s)
+*.conf

--- a/RealEstate/settings/prod.py
+++ b/RealEstate/settings/prod.py
@@ -1,6 +1,8 @@
 """
 Settings that are specific to a production environment.
 """
+from ConfigParser import RawConfigParser
+from django.core.exceptions import ImproperlyConfigured
 from RealEstate.settings.base import *
 
 STATIC_ROOT = "/opt/myenv/static/"
@@ -13,10 +15,38 @@ TEMPLATE_DEBUG = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'django',                      
+        'NAME': 'django',
         'USER': 'postgres',
         'PASSWORD': 'pass',
         'HOST': 'localhost',
-	'PORT': '',
+        'PORT': '',
     }
 }
+
+
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+
+# Expects a config file in the project directory which contains private
+# information that should not be stored in the repository, such as the
+# host email/password.
+PROJECT_CONFIG_FILE = os.path.join(BASE_DIR, 'real-estate.conf')
+parser = RawConfigParser()
+parser.optionxform = str
+parsed_files = parser.read([PROJECT_CONFIG_FILE])
+
+if not parsed_files:
+    raise ImproperlyConfigured("Failed to parse project config file. Make "
+                               "sure the file exists and is located at "
+                               "{config_file}".format(
+                                   config_file=PROJECT_CONFIG_FILE))
+
+if not all([parser.has_section('email'),
+            parser.has_option('email', 'email'),
+            parser.has_option('email', 'password')]):
+    raise ImproperlyConfigured("Config file must contain an 'email' section "
+                               "with 'email' and 'password' options.")
+
+EMAIL_HOST_USER = parser.get('email', 'email')
+EMAIL_HOST_PASSWORD = parser.get('email', 'password')


### PR DESCRIPTION
When using production settings, actually send out the emails instead of printing them to the console.  I created a gmail account for sending out the invitation emails.  The actual email/password are kept in an external config file to prevent the password from being shared in this public repo.  In order to set this up for production, the real-estate.conf file needs to be copied from the [Config](https://drive.google.com/drive/folders/0BySvjEj8bWEqflVHQXVCX0lkX3JmcUZtemJJLUZIdTJ0UUFSUVp6Wk5iS01DWl9lN1pRR0k) directory into the project root directory (alongside requirements.txt).  If this config file is not present, or the expected format is not correct, it will raise ImproperlyConfigured.
