### PR TITLE
App name extraction

### DIFF
--- a/RealEstate/apps/core/context_processors.py
+++ b/RealEstate/apps/core/context_processors.py
@@ -1,4 +1,9 @@
+from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
+
+
+def app_name(request):
+    return {'app_name': settings.APP_NAME}
 
 
 def async_login_form(request):

--- a/RealEstate/apps/core/templates/core/base.html
+++ b/RealEstate/apps/core/templates/core/base.html
@@ -9,9 +9,9 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
     <meta charset="UTF-8">
-    <title>{% block title %}Real Estate{% endblock %}</title>
+    <title>{% block title %}{{ app_name }}{% endblock %}</title>
     <meta name="author" content="Portland State University Capstone Spring 2015 Team G">
-    <meta name="description" content="Real Estate Decisions">
+    <meta name="description" content="{{ app_name }}">
     <meta name="keywords" content="realestate">
     <link href={% static "core/css/login.css" %} rel="stylesheet" type="text/css" />
     {% bootstrap_css %}
@@ -36,7 +36,8 @@
                 <span class="icon-bar"></span>
               </button>
               <a class="navbar-brand" href="{% url 'home' %}">
-                <span class="glyphicon glyphicon-home" aria-hidden="true"></span> Real Estate App
+                <span class="glyphicon glyphicon-home" aria-hidden="true"></span>
+                {{ app_name }}
               </a>
             </div>
 

--- a/RealEstate/apps/pending/models.py
+++ b/RealEstate/apps/pending/models.py
@@ -74,7 +74,7 @@ class PendingHomebuyer(BaseModel):
     _HOMEBUYER_INVITE_MESSAGE = """
         Hello {name},
 
-        You have been invited to the Real Estate app.
+        You have been invited to {app_name}.
         Register at the following link:
             {signup_link}
 
@@ -159,12 +159,14 @@ class PendingHomebuyer(BaseModel):
         if self.registered:
             return None
 
+        app_name = settings.APP_NAME
+        subject = u"{app_name} Invitation".format(app_name=app_name)
         message = self._HOMEBUYER_INVITE_MESSAGE.format(
             name=self.first_name,
+            app_name=app_name,
             signup_link=self._signup_link(request.get_host()))
-        return send_mail('Real Estate Invite', message,
-                         settings.EMAIL_HOST_USER, [self.email],
-                         fail_silently=False)
+        return send_mail(subject, message, settings.EMAIL_HOST_USER,
+                         [self.email], fail_silently=False)
 
     class Meta:
         ordering = ['email']

--- a/RealEstate/apps/pending/views.py
+++ b/RealEstate/apps/pending/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.db import transaction
@@ -64,10 +65,11 @@ class HomebuyerSignupView(View):
 
         msg = ("Welcome, {name}.<br>You have been invited by {realtor_name} "
                "({realtor_email}).<br>Please fill out the form below to "
-               "register for the Real Estate App.".format(
+               "register for {app_name}.".format(
                    name=pending_homebuyer.first_name,
                    realtor_name=realtor.full_name,
-                   realtor_email=realtor.email))
+                   realtor_email=realtor.email,
+                   app_name=settings.APP_NAME))
         messages.info(request, msg)
         return render(request, self.template_name, context)
 

--- a/RealEstate/settings/base.py
+++ b/RealEstate/settings/base.py
@@ -32,6 +32,8 @@ ALLOWED_HOSTS = []
 
 AUTH_USER_MODEL = 'core.User'
 
+APP_NAME = 'Real Estate App'
+
 INSTALLED_APPS = (
     # Default Django apps
     'django.contrib.admin',
@@ -106,6 +108,7 @@ TEMPLATES = [ {
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'RealEstate.apps.core.context_processors.app_name',
                 'RealEstate.apps.core.context_processors.async_login_form',
             ],
         },


### PR DESCRIPTION
Currently we just have a generic name for the app, "Real Estate App".  Added a setting called APP_NAME, then replaced hard coded references to the app name with that setting.  So if we decide to change the name in the future, we just replace it in one spot, and all references in the code that use it  will be updated accordingly.
